### PR TITLE
Include mobile-web-app and icon tags for iOS

### DIFF
--- a/scripts/_HTML.js
+++ b/scripts/_HTML.js
@@ -46,8 +46,11 @@ module.exports = function(fileName, content, folder, callback) {
     <meta name="twitter:description" content="${content.description}">
     <meta name="twitter:image" content="${twitterImage}">
     <meta name="article:section" content="${content.section}">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-capable" content="yes">
     <title>${content.title}</title>
     <link rel="icon" type="image/png" href="/icon/favicon.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="/icon/apple-touch-icon.png">
     <script>
       var segmentCount = 0;
       var l = window.location;


### PR DESCRIPTION
Hi, I really enjoy using Apkallu Falls to track my character.
However if it would behave as a native mobile-web-app after adding it to my home screen things
would be way more convenient (no url bars, not tab/navigation bar, a proper home screen icon).

This PR adds the meta-tags for mobile-web-app-capable
as well as includes the already present apple-touch-icon so Apkallu Falls
can work as an almost-native app when used with Safari's 'Add to Home Screen'.